### PR TITLE
Removed dependencies from readme and added them to package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ This plugin helps when using react-intl for internationalization of react apps.
 
 `npm install react-intl-webpack-plugin --save-dev`
 
-- this works only with babel-loader >= 6.4.0
-- you will need also the babel plugin `babel-plugin-react-intl`
-
 webpack.config.js:
 - add the plugin
 ```

--- a/package.json
+++ b/package.json
@@ -7,5 +7,9 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/Ognian/react-intl-webpack-plugin.git"
+    },
+    "dependencies": {
+        "babel-loader": "^6.0.0",
+        "babel-plugin-react-intl": "^2.3.0"
     }
 }


### PR DESCRIPTION
Hi,

I removed the extra instructions from the readme and added them to the package.json. This way, when someone installs your plugin, the appropriate babel plugins will be automatically installed :)