### PR TITLE
fix: use valid semver for peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-intl-webpack-plugin",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "author": "Ognian Tschakalov",
     "description": "ReactIntlPlugin for webpack",
     "license": "MIT",
@@ -9,8 +9,8 @@
         "url": "https://github.com/Ognian/react-intl-webpack-plugin.git"
     },
     "peerDependencies": {
-        "babel-loader": ">= ^6.0.0",
-        "babel-plugin-react-intl": ">= ^2.3.0",
-        "webpack":">= ^4.0.0"
+        "babel-loader": ">= 6.0.0",
+        "babel-plugin-react-intl": ">= 2.3.0",
+        "webpack":">= 4.0.0"
     }
 }


### PR DESCRIPTION
I'm not sure what the correct intended version is here, but `>= ^6.0.0` is invalid (try `babel-loader` with this range on https://semver.npmjs.com/).

So setting these to `>=` to provide the most flexibility to consumers, but not sure if it's supported with versions 7 or 8. 